### PR TITLE
Use same userId for token as it was used for autorization

### DIFF
--- a/src/Drahak/OAuth2/Grant/AuthorizationCode.php
+++ b/src/Drahak/OAuth2/Grant/AuthorizationCode.php
@@ -17,6 +17,9 @@ class AuthorizationCode extends GrantType
 	/** @var array */
 	private $scope = array();
 
+	/** @var Storage\AuthorizationCodes\AuthorizationCode */
+	private $entity;
+
 	/**
 	 * @return array
 	 */
@@ -42,8 +45,8 @@ class AuthorizationCode extends GrantType
 	{
 		$code = $this->input->getParameter('code');
 
-		$entity = $this->token->getToken(ITokenFacade::AUTHORIZATION_CODE)->getEntity($code);
-		$this->scope = $entity->getScope();
+		$this->entity = $this->token->getToken(ITokenFacade::AUTHORIZATION_CODE)->getEntity($code);
+		$this->scope = $this->entity->getScope();
 
 		$this->token->getToken(ITokenFacade::AUTHORIZATION_CODE)->getStorage()->remove($code);
 	}
@@ -58,8 +61,8 @@ class AuthorizationCode extends GrantType
 		$accessTokenStorage = $this->token->getToken(ITokenFacade::ACCESS_TOKEN);
 		$refreshTokenStorage = $this->token->getToken(ITokenFacade::REFRESH_TOKEN);
 
-		$accessToken = $accessTokenStorage->create($client, $this->user->getId(), $this->getScope());
-		$refreshToken = $refreshTokenStorage->create($client, $this->user->getId(), $this->getScope());
+		$accessToken = $accessTokenStorage->create($client, $this->user->getId() ?: $this->entity->getUserId(), $this->getScope());
+		$refreshToken = $refreshTokenStorage->create($client, $this->user->getId() ?: $this->entity->getUserId(), $this->getScope());
 
 		return array(
 			'access_token' => $accessToken->getAccessToken(),


### PR DESCRIPTION
Authorization token is created with user_id in database. This value is missing in token table after successful authorization. The value is not fetched from authorization token and stored for further use.

Please confirm the implementation, maybe you have different approach how to know currently logged in user.