### PR TITLE
Fix - client_id might be a string as deffined in sql preview (Dibi)

### DIFF
--- a/src/Drahak/OAuth2/Storage/Dibi/ClientStorage.php
+++ b/src/Drahak/OAuth2/Storage/Dibi/ClientStorage.php
@@ -42,7 +42,7 @@ class ClientStorage extends Object implements IClientStorage
 	{
 		if (!$clientId) return NULL;
 
-		$selection = $this->context->select('*')->from($this->getTable())->where('client_id = %i', $clientId);
+		$selection = $this->context->select('*')->from($this->getTable())->where('client_id = %s', $clientId);
 		if ($clientSecret) {
 			$selection->where('secret = %s', $clientSecret);
 		}


### PR DESCRIPTION
Caused by this bug there could be anystring as client_id, because it was translated as 0 and authorization was done only by client_secret